### PR TITLE
Added support of XLOG_RESTORE_POINT.

### DIFF
--- a/xlogdump_rmgr.c
+++ b/xlogdump_rmgr.c
@@ -249,6 +249,14 @@ print_rmgr_xlog(XLogRecPtr cur, XLogRecord *record, uint8 info, bool hideTimesta
 	}
 #endif
 
+#if PG_VERSION_NUM >= 90100
+	case XLOG_RESTORE_POINT:
+	{
+		snprintf(buf, sizeof(buf), "restore point:");
+		break;
+	}
+#endif
+
 	default:
 		snprintf(buf, sizeof(buf), "unknown XLOG operation - %d.", info);
 		break;


### PR DESCRIPTION
This record type was added at PG 9.1, but is not supported yet.
Sorry but I tested this patch only against 9.1.1 and 8.4.10.
